### PR TITLE
PR #3: Onboarding flow + Bottom navigation + Extended DataStore preferences

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,9 +25,22 @@ render.experimental.xml
 # Keystore files
 *.jks
 *.keystore
+*.p12
+*.pem
 
 # Google Services (e.g. APIs or Firebase)
 google-services.json
 
+# Environment and secrets
+*.env
+*.env.*
+secrets.properties
+credentials.json
+service-account.json
+
 # Android Profiling
 *.hprof
+
+# OS files
+.DS_Store
+Thumbs.db

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md - FitApp
+
+## Project
+Android fitness app (Kotlin 2.0.0, Jetpack Compose + Material 3, minSdk 29, targetSdk 35).
+
+## Build commands
+```bash
+./gradlew assembleDebug          # Build debug APK (run from FitApp2/)
+./gradlew test                    # Unit tests
+./gradlew connectedAndroidTest    # Instrumentation tests (needs emulator)
+```
+- Dependencies version catalog: `FitApp2/gradle/libs.versions.toml`
+- Missing `google-services.json` is expected (gitignored), app fails at runtime without it
+
+## Architecture
+Clean Architecture + MVI (hand-rolled, not a library).
+- DI: Hilt — `@HiltAndroidApp` on `FitApplication`, `@AndroidEntryPoint` on Activities, `@HiltViewModel` on ViewModels
+- DB: Room 2.6.1 → `AppDatabase` with `user_table` and `steps_table`
+- Auth: Firebase Auth
+- Session: DataStore Preferences (`user_session`)
+- Sensor: `TYPE_STEP_COUNTER` hardware sensor via `StepCounter`
+- Background: WorkManager → `StepCountWorker`
+
+## MVI pattern
+Every feature needs: `State`, `Event`, `Effect`, `ViewModel`, `Screen`.
+- Base: `BaseViewModel<Event, State, Effect>` at `mvi/projectStructure/BaseViewModel.kt`
+- `createInitialState()` = abstract, return idle state
+- `handleEvent(event)` = abstract, dispatch to private methods
+- `setState { }` = reducer-style state updates
+- `setEffect { }` = one-shot side effects (toast, navigation)
+- Collect effects via `LaunchedEffect(Unit) { viewModel.effect.collect { ... } }` in Composable
+- Reference: `LoginViewModel` is the cleanest example
+
+## Package layout
+```
+com.example.fitapp/
+  data/local/       → Room DB, DataStore, StepCounter sensor, DI modules
+  data/remote/      → Firebase Auth, DI modules  
+  domain/entities/  → Room @Entity
+  domain/model/     → Domain models
+  domain/usecases/  → Use cases
+  domain/worker/    → WorkManager workers
+  presentation/ui/
+    component/      → Reusable composables
+    mvi/            → Base MVI + per-feature effect/event/state + BaseViewModel
+    screens/        → Full screen composables
+    theme/          → Colors, Typography, Theme
+    viewModel/      → Hilt ViewModels
+```
+⚠ `AuthScreen` is in `presentation/ui/theme/screen/LoginScreen.kt` — move to `screens/` eventually.
+
+## Entry points
+- `LoginActivity` (launcher, exported=true) → auth + ACTIVITY_RECOGNITION permission
+- `MainActivity` → dashboard after login
+- `FitApplication` → initializes Firebase
+
+## Testing
+- JUnit 4, Espresso, Compose UI test — all configured but tests are template-only
+- Min 70% coverage target on domain layer
+
+## Gotchas
+- `StepCounter.steps()` uses `suspendCancellableCoroutine` — hangs until sensor fires; only call in Worker/coroutine
+- `SensorRepositoryImpl.getSteps()` computes today as `last - first` data point → needs both start and end of day data
+- Release builds have ProGuard enabled — keep rules in `proguard-rules.pro` for Room, Hilt, Firebase, domain models
+- Network security config at `res/xml/network_security_config.xml` — update when adding new API domains

--- a/FitApp2/app/build.gradle.kts
+++ b/FitApp2/app/build.gradle.kts
@@ -29,7 +29,7 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
@@ -65,7 +65,8 @@ dependencies {
     implementation(libs.androidx.connect.client)
 
     //DataStore
-    implementation (libs.androidx.datastore.preferences)
+    implementation(libs.androidx.datastore.preferences)
+    implementation("androidx.security:security-crypto:1.1.0-alpha06")
     // Room dependencies
     implementation(libs.androidx.room.runtime)
     implementation(libs.androidx.room.ktx)

--- a/FitApp2/app/proguard-rules.pro
+++ b/FitApp2/app/proguard-rules.pro
@@ -1,21 +1,47 @@
-# Add project specific ProGuard rules here.
-# You can control the set of applied configuration files using the
-# proguardFiles setting in build.gradle.
-#
-# For more details, see
-#   http://developer.android.com/guide/developing/tools/proguard.html
+# App-specific ProGuard rules
 
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
+# Keep data classes used with Firebase
+-keepattributes Signature
+-keepattributes *Annotation*
 
-# Uncomment this to preserve the line number information for
-# debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
+# Firebase
+-keep class com.google.firebase.** { *; }
+-dontwarn com.google.firebase.**
 
-# If you keep the line number information, uncomment this to
-# hide the original source file name.
-#-renamesourcefileattribute SourceFile
+# Room
+-keep class * extends androidx.room.RoomDatabase
+-keep @androidx.room.Entity class *
+-dontwarn androidx.room.paging.**
+
+# Hilt
+-keep class dagger.hilt.** { *; }
+-keep class javax.inject.** { *; }
+-keep class * extends dagger.hilt.android.internal.managers.ViewComponentManager$FragmentContextWrapper { *; }
+
+# Compose
+-dontwarn androidx.compose.**
+
+# DataStore
+-keep class androidx.datastore.** { *; }
+
+# Coroutines
+-keepnames class kotlinx.coroutines.internal.MainDispatcherFactory {}
+-keepnames class kotlinx.coroutines.CoroutineExceptionHandler {}
+
+# Keep FitApp domain models
+-keep class com.example.fitapp.domain.entities.** { *; }
+-keep class com.example.fitapp.domain.model.** { *; }
+
+# Remove logging in release
+-assumenosideeffects class android.util.Log {
+    public static boolean isLoggable(java.lang.String, int);
+    public static int v(...);
+    public static int d(...);
+    public static int i(...);
+    public static int w(...);
+    public static int e(...);
+}
+
+# Preserve line numbers for crash reports
+-keepattributes SourceFile,LineNumberTable
+-renamesourcefileattribute SourceFile

--- a/FitApp2/app/src/main/AndroidManifest.xml
+++ b/FitApp2/app/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_HEALTH"/>
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:name=".FitApplication"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
@@ -19,6 +19,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.FitApp"
+        android:networkSecurityConfig="@xml/network_security_config"
         tools:targetApi="31">
         <activity
             android:name=".LoginActivity"

--- a/FitApp2/app/src/main/java/com/example/fitapp/MainActivity.kt
+++ b/FitApp2/app/src/main/java/com/example/fitapp/MainActivity.kt
@@ -4,19 +4,13 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
+import androidx.compose.runtime.getValue
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.example.fitapp.presentation.ui.mvi.event.MainActivityEvent
-import com.example.fitapp.presentation.ui.mvi.state.MainActivityState
-import com.example.fitapp.presentation.ui.screens.DashboardScreen
+import com.example.fitapp.presentation.ui.navigation.AppNavigation
+import com.example.fitapp.presentation.ui.screens.onboarding.OnboardingScreen
 import com.example.fitapp.presentation.ui.theme.FitAppTheme
+import com.example.fitapp.presentation.ui.theme.ThemeMode
 import com.example.fitapp.presentation.ui.viewModel.MainActivityViewModel
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -28,36 +22,17 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             val viewModel: MainActivityViewModel = hiltViewModel()
-            val state = viewModel.uiState.collectAsState()
+            val onboardingCompleted by viewModel.onboardingCompleted.collectAsState(initial = false)
 
-            LaunchedEffect(Unit) {
-                viewModel.setEvent(MainActivityEvent.Loading("", ""))
-            }
-
-            FitAppTheme {
-                DashboardScreen()
-                when (state.value) {
-                    is MainActivityState.Idle -> {}
-                    is MainActivityState.Loading -> {}
-                    is MainActivityState.Error -> {
-                        Text(
-                            text = "Error: ${(state.value as MainActivityState.Error).error}",
-                            modifier = Modifier.padding(16.dp)
-                        )
-                    }
-                    is MainActivityState.Success -> {
-                        Text(
-                            text = "Steps: ${(state.value as MainActivityState.Success).steps}",
-                            modifier = Modifier.padding(16.dp)
-                        )
-                    }
+            FitAppTheme(themeMode = ThemeMode.DARK) {
+                if (!onboardingCompleted) {
+                    OnboardingScreen(
+                        onCompleted = { viewModel.completeOnboarding() }
+                    )
+                } else {
+                    AppNavigation()
                 }
             }
         }
     }
-}
-
-@Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(text = "Hello $name!", modifier = modifier)
 }

--- a/FitApp2/app/src/main/java/com/example/fitapp/MainActivity.kt
+++ b/FitApp2/app/src/main/java/com/example/fitapp/MainActivity.kt
@@ -1,23 +1,20 @@
 package com.example.fitapp
 
-import MainActivityState
 import android.os.Bundle
-import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.example.fitapp.presentation.ui.component.DashboardToolBar
+import com.example.fitapp.presentation.ui.mvi.event.MainActivityEvent
+import com.example.fitapp.presentation.ui.mvi.state.MainActivityState
 import com.example.fitapp.presentation.ui.screens.DashboardScreen
 import com.example.fitapp.presentation.ui.theme.FitAppTheme
 import com.example.fitapp.presentation.ui.viewModel.MainActivityViewModel
@@ -28,64 +25,39 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
         enableEdgeToEdge()
         setContent {
-
             val viewModel: MainActivityViewModel = hiltViewModel()
             val state = viewModel.uiState.collectAsState()
 
+            LaunchedEffect(Unit) {
+                viewModel.setEvent(MainActivityEvent.Loading("", ""))
+            }
 
             FitAppTheme {
                 DashboardScreen()
                 when (state.value) {
-                    is MainActivityState.Idle -> {
-                        Log.d("MainActivity", "state -> ${state.value}")
-                        viewModel.setEvent(MainActivityEvent.Loading("email", "password"))
-                    }
-                    is MainActivityState.Loading -> {
-                        Log.d("MainActivity", "state -> ${state.value}")
-                    }
+                    is MainActivityState.Idle -> {}
+                    is MainActivityState.Loading -> {}
                     is MainActivityState.Error -> {
-                        Text(text = "Error: ${(state.value as MainActivityState.Error).error}", modifier = Modifier.padding(16.dp))
-                        Log.d("MainActivity", "state -> ${state.value}")
+                        Text(
+                            text = "Error: ${(state.value as MainActivityState.Error).error}",
+                            modifier = Modifier.padding(16.dp)
+                        )
                     }
                     is MainActivityState.Success -> {
-                        Log.d("MainActivity", "state -> ${state.value}")
-                        Text(text = "Success: ${(state.value as MainActivityState.Success).steps}", modifier = Modifier.padding(16.dp))
-
+                        Text(
+                            text = "Steps: ${(state.value as MainActivityState.Success).steps}",
+                            modifier = Modifier.padding(16.dp)
+                        )
                     }
-
-                    else -> {}
                 }
-
             }
         }
-    }
-
-
-}
-
-@Preview(showBackground = true)
-@Composable
-fun DashboardPreview() {
-    FitAppTheme {
-        DashboardScreen()
     }
 }
 
 @Composable
 fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
-        modifier = modifier
-    )
-}
-
-@Preview(showBackground = true)
-@Composable
-fun GreetingPreview() {
-    FitAppTheme {
-        Greeting("Android")
-    }
+    Text(text = "Hello $name!", modifier = modifier)
 }

--- a/FitApp2/app/src/main/java/com/example/fitapp/data/local/datastore/DataStoreManager.kt
+++ b/FitApp2/app/src/main/java/com/example/fitapp/data/local/datastore/DataStoreManager.kt
@@ -5,6 +5,7 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import kotlinx.coroutines.flow.Flow
@@ -12,19 +13,22 @@ import kotlinx.coroutines.flow.map
 
 val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "user_session")
 
-class DataStoreManager(Context: Context) {
+class DataStoreManager(context: Context) {
 
-    private val dataStore: DataStore<Preferences> = Context.dataStore
+    private val dataStore: DataStore<Preferences> = context.dataStore
 
     companion object {
-
         val IS_LOGGED_IN = booleanPreferencesKey("is_logged_in")
         val USER_EMAIL = stringPreferencesKey("user_email")
-
+        val ONBOARDING_COMPLETED = booleanPreferencesKey("onboarding_completed")
+        val THEME_MODE = intPreferencesKey("theme_mode")
+        val DAILY_STEP_GOAL = intPreferencesKey("daily_step_goal")
+        val DAILY_CALORIE_GOAL = intPreferencesKey("daily_calorie_goal")
+        val WORKOUTS_PER_WEEK_GOAL = intPreferencesKey("workouts_per_week_goal")
+        val UNIT_SYSTEM = stringPreferencesKey("unit_system")
     }
 
-
-   suspend fun saveSession(isLoggedIn: Boolean, userEmail: String) {
+    suspend fun saveSession(isLoggedIn: Boolean, userEmail: String) {
         dataStore.edit { preferences ->
             preferences[IS_LOGGED_IN] = isLoggedIn
             preferences[USER_EMAIL] = userEmail
@@ -32,17 +36,15 @@ class DataStoreManager(Context: Context) {
     }
 
     fun readLoggedInState(): Flow<Boolean> {
-        return dataStore.data
-            .map { preferences ->
-                preferences[IS_LOGGED_IN] ?: false
-            }
+        return dataStore.data.map { preferences ->
+            preferences[IS_LOGGED_IN] ?: false
+        }
     }
 
     fun readUserId(): Flow<String?> {
-        return dataStore.data
-            .map { preferences ->
-                preferences[USER_EMAIL]
-            }
+        return dataStore.data.map { preferences ->
+            preferences[USER_EMAIL]
+        }
     }
 
     suspend fun clearSession() {
@@ -52,7 +54,75 @@ class DataStoreManager(Context: Context) {
         }
     }
 
-
-
-
+    suspend fun setOnboardingCompleted() {
+        dataStore.edit { preferences ->
+            preferences[ONBOARDING_COMPLETED] = true
+        }
     }
+
+    fun isOnboardingCompleted(): Flow<Boolean> {
+        return dataStore.data.map { preferences ->
+            preferences[ONBOARDING_COMPLETED] ?: false
+        }
+    }
+
+    suspend fun saveThemeMode(mode: Int) {
+        dataStore.edit { preferences ->
+            preferences[THEME_MODE] = mode
+        }
+    }
+
+    fun readThemeMode(): Flow<Int> {
+        return dataStore.data.map { preferences ->
+            preferences[THEME_MODE] ?: 1
+        }
+    }
+
+    suspend fun saveStepGoal(steps: Int) {
+        dataStore.edit { preferences ->
+            preferences[DAILY_STEP_GOAL] = steps
+        }
+    }
+
+    fun readStepGoal(): Flow<Int> {
+        return dataStore.data.map { preferences ->
+            preferences[DAILY_STEP_GOAL] ?: 10000
+        }
+    }
+
+    suspend fun saveCalorieGoal(calories: Int) {
+        dataStore.edit { preferences ->
+            preferences[DAILY_CALORIE_GOAL] = calories
+        }
+    }
+
+    fun readCalorieGoal(): Flow<Int> {
+        return dataStore.data.map { preferences ->
+            preferences[DAILY_CALORIE_GOAL] ?: 2000
+        }
+    }
+
+    suspend fun saveWorkoutsPerWeekGoal(count: Int) {
+        dataStore.edit { preferences ->
+            preferences[WORKOUTS_PER_WEEK_GOAL] = count
+        }
+    }
+
+    fun readWorkoutsPerWeekGoal(): Flow<Int> {
+        return dataStore.data.map { preferences ->
+            preferences[WORKOUTS_PER_WEEK_GOAL] ?: 4
+        }
+    }
+
+    suspend fun saveUnitSystem(unit: String) {
+        dataStore.edit { preferences ->
+            preferences[UNIT_SYSTEM] = unit
+        }
+    }
+
+    fun readUnitSystem(): Flow<String> {
+        return dataStore.data.map { preferences ->
+            preferences[UNIT_SYSTEM] ?: "metric"
+        }
+    }
+}

--- a/FitApp2/app/src/main/java/com/example/fitapp/presentation/ui/component/DateText.kt
+++ b/FitApp2/app/src/main/java/com/example/fitapp/presentation/ui/component/DateText.kt
@@ -5,25 +5,22 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.dp
-
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-
+import androidx.compose.ui.unit.dp
 
 @Composable
 fun DateText(text: String, modifier: Modifier = Modifier) {
-    Text(text = "16 DE JUNIO DE 2022",
+    Text(
+        text = text,
         color = Color.White,
         textAlign = TextAlign.Center,
         fontWeight = FontWeight.Bold,
         modifier = modifier
             .background(color = Color.Gray)
             .fillMaxWidth()
-            .padding( 10.dp)
+            .padding(10.dp)
     )
 }

--- a/FitApp2/app/src/main/java/com/example/fitapp/presentation/ui/component/FitBottomNav.kt
+++ b/FitApp2/app/src/main/java/com/example/fitapp/presentation/ui/component/FitBottomNav.kt
@@ -1,0 +1,71 @@
+package com.example.fitapp.presentation.ui.component
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DirectionsRun
+import androidx.compose.material.icons.filled.EmojiEvents
+import androidx.compose.material.icons.filled.FitnessCenter
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.TrendingUp
+import androidx.compose.material.icons.outlined.DirectionsRun
+import androidx.compose.material.icons.outlined.EmojiEvents
+import androidx.compose.material.icons.outlined.FitnessCenter
+import androidx.compose.material.icons.outlined.Home
+import androidx.compose.material.icons.outlined.Person
+import androidx.compose.material.icons.outlined.TrendingUp
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.NavigationBarItemDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+
+enum class BottomNavItem(
+    val label: String,
+    val selectedIcon: ImageVector,
+    val unselectedIcon: ImageVector
+) {
+    HOME("Home", Icons.Filled.Home, Icons.Outlined.Home),
+    WORKOUTS("Workouts", Icons.Filled.FitnessCenter, Icons.Outlined.FitnessCenter),
+    TRACKING("Track", Icons.Filled.DirectionsRun, Icons.Outlined.DirectionsRun),
+    PROGRESS("Progress", Icons.Filled.TrendingUp, Icons.Outlined.TrendingUp),
+    PROFILE("Profile", Icons.Filled.Person, Icons.Outlined.Person)
+}
+
+@Composable
+fun FitBottomNav(
+    selectedTab: BottomNavItem,
+    onTabSelected: (BottomNavItem) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    NavigationBar(
+        modifier = modifier,
+        containerColor = MaterialTheme.colorScheme.surface,
+        contentColor = MaterialTheme.colorScheme.primary
+    ) {
+        BottomNavItem.entries.forEach { item ->
+            val selected = item == selectedTab
+            NavigationBarItem(
+                selected = selected,
+                onClick = { onTabSelected(item) },
+                icon = {
+                    Icon(
+                        imageVector = if (selected) item.selectedIcon else item.unselectedIcon,
+                        contentDescription = item.label
+                    )
+                },
+                label = { Text(text = item.label) },
+                colors = NavigationBarItemDefaults.colors(
+                    selectedIconColor = MaterialTheme.colorScheme.primary,
+                    selectedTextColor = MaterialTheme.colorScheme.primary,
+                    unselectedIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                    unselectedTextColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                    indicatorColor = MaterialTheme.colorScheme.primaryContainer
+                )
+            )
+        }
+    }
+}

--- a/FitApp2/app/src/main/java/com/example/fitapp/presentation/ui/component/FitButton.kt
+++ b/FitApp2/app/src/main/java/com/example/fitapp/presentation/ui/component/FitButton.kt
@@ -1,0 +1,94 @@
+package com.example.fitapp.presentation.ui.component
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.example.fitapp.presentation.ui.theme.ButtonShape
+
+@Composable
+fun FitPrimaryButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    icon: ImageVector? = null,
+    fullWidth: Boolean = false
+) {
+    Button(
+        onClick = onClick,
+        modifier = modifier
+            .then(if (fullWidth) Modifier.fillMaxWidth() else Modifier)
+            .height(48.dp),
+        enabled = enabled,
+        shape = ButtonShape,
+        colors = ButtonDefaults.buttonColors(
+            containerColor = MaterialTheme.colorScheme.primary,
+            contentColor = MaterialTheme.colorScheme.onPrimary
+        )
+    ) {
+        if (icon != null) {
+            Icon(imageVector = icon, contentDescription = null, modifier = Modifier.size(20.dp))
+            androidx.compose.foundation.layout.Spacer(modifier = Modifier.size(8.dp))
+        }
+        Text(text = text, style = MaterialTheme.typography.labelLarge, fontWeight = FontWeight.SemiBold)
+    }
+}
+
+@Composable
+fun FitSecondaryButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    icon: ImageVector? = null,
+    fullWidth: Boolean = false
+) {
+    OutlinedButton(
+        onClick = onClick,
+        modifier = modifier
+            .then(if (fullWidth) Modifier.fillMaxWidth() else Modifier)
+            .height(48.dp),
+        enabled = enabled,
+        shape = ButtonShape,
+        colors = ButtonDefaults.outlinedButtonColors(
+            contentColor = MaterialTheme.colorScheme.primary
+        )
+    ) {
+        if (icon != null) {
+            Icon(imageVector = icon, contentDescription = null, modifier = Modifier.size(20.dp))
+            androidx.compose.foundation.layout.Spacer(modifier = Modifier.size(8.dp))
+        }
+        Text(text = text, style = MaterialTheme.typography.labelLarge, fontWeight = FontWeight.SemiBold)
+    }
+}
+
+@Composable
+fun FitTextButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    color: Color = MaterialTheme.colorScheme.primary
+) {
+    TextButton(onClick = onClick, modifier = modifier) {
+        Text(
+            text = text,
+            color = color,
+            style = MaterialTheme.typography.labelLarge,
+            fontWeight = FontWeight.Medium
+        )
+    }
+}

--- a/FitApp2/app/src/main/java/com/example/fitapp/presentation/ui/component/FitCard.kt
+++ b/FitApp2/app/src/main/java/com/example/fitapp/presentation/ui/component/FitCard.kt
@@ -1,0 +1,53 @@
+package com.example.fitapp.presentation.ui.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.example.fitapp.presentation.ui.theme.CardShape
+
+@Composable
+fun FitCard(
+    modifier: Modifier = Modifier,
+    title: String? = null,
+    subtitle: String? = null,
+    onClick: (() -> Unit)? = null,
+    content: @Composable ColumnScope.() -> Unit = {}
+) {
+    Column(
+        modifier = modifier
+            .clip(CardShape)
+            .background(MaterialTheme.colorScheme.surface)
+            .then(if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier)
+            .padding(16.dp)
+    ) {
+        if (title != null) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+        }
+        if (subtitle != null) {
+            Text(
+                text = subtitle,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = 4.dp)
+            )
+        }
+        if (title != null || subtitle != null) {
+            androidx.compose.foundation.layout.Spacer(modifier = Modifier.padding(top = 8.dp))
+        }
+        content()
+    }
+}

--- a/FitApp2/app/src/main/java/com/example/fitapp/presentation/ui/component/FitProgressRing.kt
+++ b/FitApp2/app/src/main/java/com/example/fitapp/presentation/ui/component/FitProgressRing.kt
@@ -1,0 +1,112 @@
+package com.example.fitapp.presentation.ui.component
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.example.fitapp.presentation.ui.theme.HeroNumberStyle
+
+@Composable
+fun FitProgressRing(
+    progress: Float,
+    target: Float,
+    modifier: Modifier = Modifier,
+    size: Dp = 120.dp,
+    strokeWidth: Dp = 10.dp,
+    progressColor: Color = MaterialTheme.colorScheme.primary,
+    trackColor: Color = MaterialTheme.colorScheme.surfaceVariant,
+    label: String = "",
+    suffix: String = ""
+) {
+    val animatedProgress by animateFloatAsState(
+        targetValue = (progress / target).coerceIn(0f, 1f),
+        animationSpec = tween(durationMillis = 1000),
+        label = "progress"
+    )
+
+    Box(contentAlignment = Alignment.Center, modifier = modifier.size(size)) {
+        Canvas(modifier = Modifier.size(size)) {
+            val stroke = strokeWidth.toPx()
+            val arcSize = Size(size.toPx() - stroke, size.toPx() - stroke)
+            val topLeft = Offset(stroke / 2, stroke / 2)
+
+            drawArc(
+                color = trackColor,
+                startAngle = -90f,
+                sweepAngle = 360f,
+                useCenter = false,
+                size = arcSize,
+                topLeft = topLeft,
+                style = Stroke(width = stroke, cap = StrokeCap.Round)
+            )
+
+            drawArc(
+                color = progressColor,
+                startAngle = -90f,
+                sweepAngle = 360f * animatedProgress,
+                useCenter = false,
+                size = arcSize,
+                topLeft = topLeft,
+                style = Stroke(width = stroke, cap = StrokeCap.Round)
+            )
+        }
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(
+                text = "${progress.toInt()}$suffix",
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            if (label.isNotEmpty()) {
+                Text(
+                    text = label,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun FitLinearProgress(
+    progress: Float,
+    target: Float,
+    modifier: Modifier = Modifier,
+    height: Dp = 8.dp,
+    progressColor: Color = MaterialTheme.colorScheme.primary,
+    trackColor: Color = MaterialTheme.colorScheme.surfaceVariant
+) {
+    val animatedProgress by animateFloatAsState(
+        targetValue = (progress / target).coerceIn(0f, 1f),
+        animationSpec = tween(durationMillis = 600),
+        label = "linearProgress"
+    )
+
+    androidx.compose.material3.LinearProgressIndicator(
+        progress = { animatedProgress },
+        modifier = modifier.then(Modifier),
+        color = progressColor,
+        trackColor = trackColor,
+    )
+}

--- a/FitApp2/app/src/main/java/com/example/fitapp/presentation/ui/component/FitTextField.kt
+++ b/FitApp2/app/src/main/java/com/example/fitapp/presentation/ui/component/FitTextField.kt
@@ -1,0 +1,54 @@
+package com.example.fitapp.presentation.ui.component
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.input.VisualTransformation
+import com.example.fitapp.presentation.ui.theme.FitnessShapes
+
+@Composable
+fun FitTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    label: String,
+    modifier: Modifier = Modifier,
+    placeholder: String? = null,
+    leadingIcon: ImageVector? = null,
+    trailingIcon: ImageVector? = null,
+    isError: Boolean = false,
+    errorMessage: String? = null,
+    visualTransformation: VisualTransformation = VisualTransformation.None,
+    singleLine: Boolean = true,
+    readOnly: Boolean = false,
+    enabled: Boolean = true
+) {
+    OutlinedTextField(
+        value = value,
+        onValueChange = onValueChange,
+        label = { Text(label) },
+        placeholder = placeholder?.let { { Text(it) } },
+        modifier = modifier,
+        isError = isError,
+        supportingText = errorMessage?.let { { Text(it, color = MaterialTheme.colorScheme.error) } },
+        singleLine = singleLine,
+        readOnly = readOnly,
+        enabled = enabled,
+        visualTransformation = visualTransformation,
+        shape = FitnessShapes.medium,
+        colors = OutlinedTextFieldDefaults.colors(
+            cursorColor = MaterialTheme.colorScheme.primary,
+            focusedBorderColor = MaterialTheme.colorScheme.primary,
+            unfocusedBorderColor = MaterialTheme.colorScheme.outline,
+            errorBorderColor = MaterialTheme.colorScheme.error,
+            focusedLabelColor = MaterialTheme.colorScheme.primary,
+            unfocusedLabelColor = MaterialTheme.colorScheme.onSurfaceVariant,
+            errorLabelColor = MaterialTheme.colorScheme.error,
+            focusedSupportingTextColor = MaterialTheme.colorScheme.error,
+            unfocusedSupportingTextColor = MaterialTheme.colorScheme.error
+        )
+    )
+}

--- a/FitApp2/app/src/main/java/com/example/fitapp/presentation/ui/component/LoginForm.kt
+++ b/FitApp2/app/src/main/java/com/example/fitapp/presentation/ui/component/LoginForm.kt
@@ -22,11 +22,15 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.example.fitapp.presentation.ui.mvi.event.AuthEvent
 
+private val EMAIL_REGEX = Regex("^[A-Za-z0-9._%+\\-]+@[A-Za-z0-9.\\-]+\\.[A-Za-z]{2,}$")
+
 @Composable
-fun AuthForm(onEvent: (AuthEvent) -> Unit ) {
+fun AuthForm(onEvent: (AuthEvent) -> Unit) {
     var email by remember { mutableStateOf("") }
     var password by remember { mutableStateOf("") }
     var isLoginMode by remember { mutableStateOf(true) }
+    var emailError by remember { mutableStateOf<String?>(null) }
+    var passwordError by remember { mutableStateOf<String?>(null) }
 
     Column(
         modifier = Modifier
@@ -37,22 +41,49 @@ fun AuthForm(onEvent: (AuthEvent) -> Unit ) {
     ) {
         TextField(
             value = email,
-            onValueChange = { email = it },
-            label = { Text("Email") }
+            onValueChange = {
+                email = it
+                emailError = if (it.isNotEmpty() && !EMAIL_REGEX.matches(it.trim())) {
+                    "Invalid email format"
+                } else {
+                    null
+                }
+            },
+            label = { Text("Email") },
+            isError = emailError != null,
+            supportingText = emailError?.let { { Text(it) } },
+            singleLine = true
         )
         Spacer(modifier = Modifier.height(8.dp))
         TextField(
             value = password,
-            onValueChange = { password = it },
+            onValueChange = {
+                password = it
+                passwordError = if (it.isNotEmpty() && it.length < 8) {
+                    "Password must be at least 8 characters"
+                } else {
+                    null
+                }
+            },
             label = { Text("Password") },
-            visualTransformation = PasswordVisualTransformation()
+            visualTransformation = PasswordVisualTransformation(),
+            isError = passwordError != null,
+            supportingText = passwordError?.let { { Text(it) } },
+            singleLine = true
         )
         Spacer(modifier = Modifier.height(16.dp))
         Button(onClick = {
+            val trimmedEmail = email.trim()
+            val isValid = EMAIL_REGEX.matches(trimmedEmail) && password.length >= 8
+            if (!isValid) {
+                if (!EMAIL_REGEX.matches(trimmedEmail)) emailError = "Invalid email format"
+                if (password.length < 8) passwordError = "Password must be at least 8 characters"
+                return@Button
+            }
             if (isLoginMode) {
-                onEvent.invoke(AuthEvent.Login(email, password))
+                onEvent(AuthEvent.Login(trimmedEmail, password))
             } else {
-                onEvent.invoke(AuthEvent.Register(email, password))
+                onEvent(AuthEvent.Register(trimmedEmail, password))
             }
         }) {
             Text(text = if (isLoginMode) "Login" else "Register")
@@ -62,12 +93,10 @@ fun AuthForm(onEvent: (AuthEvent) -> Unit ) {
             Text(text = if (isLoginMode) "Switch to Register" else "Switch to Login")
         }
     }
-
-
 }
 
 @Preview
 @Composable
-fun AuthPreview(){
-    AuthForm {  }
+fun AuthPreview() {
+    AuthForm { }
 }

--- a/FitApp2/app/src/main/java/com/example/fitapp/presentation/ui/component/ScreenTransitions.kt
+++ b/FitApp2/app/src/main/java/com/example/fitapp/presentation/ui/component/ScreenTransitions.kt
@@ -1,0 +1,72 @@
+package com.example.fitapp.presentation.ui.component
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.SizeTransform
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.togetherWith
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+fun ScreenTransition(
+    targetState: Any,
+    modifier: Modifier = Modifier,
+    label: String = "screen transition",
+    content: @Composable () -> Unit
+) {
+    AnimatedContent(
+        targetState = targetState,
+        modifier = modifier,
+        transitionSpec = {
+            (fadeIn(animationSpec = tween(300)) +
+                    slideInHorizontally(animationSpec = tween(300)) { it / 4 })
+                .togetherWith(
+                    fadeOut(animationSpec = tween(300)) +
+                            slideOutHorizontally(animationSpec = tween(300)) { -it / 4 }
+                )
+                .using(SizeTransform(clip = false))
+        },
+        label = label
+    ) {
+        content()
+    }
+}
+
+@Composable
+fun FadeThrough(
+    visible: Boolean,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit
+) {
+    AnimatedVisibility(
+        visible = visible,
+        enter = fadeIn(animationSpec = tween(200)),
+        exit = fadeOut(animationSpec = tween(200)),
+        modifier = modifier
+    ) {
+        content()
+    }
+}
+
+@Composable
+fun SlideUp(
+    visible: Boolean,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit
+) {
+    AnimatedVisibility(
+        visible = visible,
+        enter = slideInVertically(animationSpec = tween(300)) { it } + fadeIn(animationSpec = tween(300)),
+        exit = slideOutVertically(animationSpec = tween(200)) { it } + fadeOut(animationSpec = tween(200)),
+        modifier = modifier
+    ) {
+        content()
+    }
+}

--- a/FitApp2/app/src/main/java/com/example/fitapp/presentation/ui/component/SkeletonLoader.kt
+++ b/FitApp2/app/src/main/java/com/example/fitapp/presentation/ui/component/SkeletonLoader.kt
@@ -1,0 +1,81 @@
+package com.example.fitapp.presentation.ui.component
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun SkeletonLoader(modifier: Modifier = Modifier) {
+    val shimmerColors = listOf(
+        MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f),
+        MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.2f),
+        MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f)
+    )
+
+    val transition = rememberInfiniteTransition(label = "shimmer")
+    val translateAnimation by transition.animateFloat(
+        initialValue = 0f,
+        targetValue = 1000f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 1200, easing = LinearEasing),
+            repeatMode = RepeatMode.Restart
+        ),
+        label = "shimmer"
+    )
+
+    val brush = Brush.linearGradient(
+        colors = shimmerColors,
+        start = Offset(translateAnimation - 200f, translateAnimation - 200f),
+        end = Offset(translateAnimation, translateAnimation)
+    )
+
+    Box(
+        modifier = modifier
+            .clip(com.example.fitapp.presentation.ui.theme.CardShape)
+            .background(brush)
+            .fillMaxWidth()
+            .height(80.dp)
+    )
+}
+
+@Composable
+fun DashboardSkeleton() {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp)
+    ) {
+        Row(modifier = Modifier.fillMaxWidth()) {
+            SkeletonLoader(modifier = Modifier.weight(1f).padding(end = 8.dp))
+            SkeletonLoader(modifier = Modifier.weight(1f).padding(start = 8.dp))
+        }
+        Spacer(modifier = Modifier.height(12.dp))
+        SkeletonLoader(modifier = Modifier.fillMaxWidth().height(120.dp))
+        Spacer(modifier = Modifier.height(12.dp))
+        SkeletonLoader(modifier = Modifier.fillMaxWidth().height(100.dp))
+        Spacer(modifier = Modifier.height(12.dp))
+        SkeletonLoader(modifier = Modifier.fillMaxWidth().height(100.dp))
+    }
+}

--- a/FitApp2/app/src/main/java/com/example/fitapp/presentation/ui/mvi/effect/MainActivityEffect.kt
+++ b/FitApp2/app/src/main/java/com/example/fitapp/presentation/ui/mvi/effect/MainActivityEffect.kt
@@ -1,3 +1,5 @@
+package com.example.fitapp.presentation.ui.mvi.effect
+
 import com.example.fitapp.presentation.ui.mvi.UIEffect
 
 sealed class MainActivityEffect: UIEffect {

--- a/FitApp2/app/src/main/java/com/example/fitapp/presentation/ui/mvi/event/MainActivityEvent.kt
+++ b/FitApp2/app/src/main/java/com/example/fitapp/presentation/ui/mvi/event/MainActivityEvent.kt
@@ -1,5 +1,6 @@
-import com.example.fitapp.presentation.ui.mvi.UIEvent
+package com.example.fitapp.presentation.ui.mvi.event
 
+import com.example.fitapp.presentation.ui.mvi.UIEvent
 
 sealed class MainActivityEvent : UIEvent {
 

--- a/FitApp2/app/src/main/java/com/example/fitapp/presentation/ui/mvi/state/MainActivityState.kt
+++ b/FitApp2/app/src/main/java/com/example/fitapp/presentation/ui/mvi/state/MainActivityState.kt
@@ -1,5 +1,6 @@
-import com.example.fitapp.presentation.ui.mvi.UIState
+package com.example.fitapp.presentation.ui.mvi.state
 
+import com.example.fitapp.presentation.ui.mvi.UIState
 
 sealed class MainActivityState: UIState {
     object Idle : MainActivityState()

--- a/FitApp2/app/src/main/java/com/example/fitapp/presentation/ui/navigation/AppNavigation.kt
+++ b/FitApp2/app/src/main/java/com/example/fitapp/presentation/ui/navigation/AppNavigation.kt
@@ -1,0 +1,66 @@
+package com.example.fitapp.presentation.ui.navigation
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import com.example.fitapp.presentation.ui.component.BottomNavItem
+import com.example.fitapp.presentation.ui.component.FitBottomNav
+import com.example.fitapp.presentation.ui.screens.DashboardScreen
+
+@Composable
+fun AppNavigation(
+    modifier: Modifier = Modifier
+) {
+    var selectedTab by remember { mutableStateOf(BottomNavItem.HOME) }
+
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        containerColor = MaterialTheme.colorScheme.background,
+        bottomBar = {
+            FitBottomNav(
+                selectedTab = selectedTab,
+                onTabSelected = { selectedTab = it }
+            )
+        }
+    ) { innerPadding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+        ) {
+            when (selectedTab) {
+                BottomNavItem.HOME -> DashboardScreen()
+                BottomNavItem.WORKOUTS -> PlaceholderScreen("Workouts")
+                BottomNavItem.TRACKING -> PlaceholderScreen("Activity Tracking")
+                BottomNavItem.PROGRESS -> PlaceholderScreen("Progress")
+                BottomNavItem.PROFILE -> PlaceholderScreen("Profile")
+            }
+        }
+    }
+}
+
+@Composable
+private fun PlaceholderScreen(title: String) {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.headlineMedium,
+            textAlign = TextAlign.Center,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}

--- a/FitApp2/app/src/main/java/com/example/fitapp/presentation/ui/screens/onboarding/OnboardingPage.kt
+++ b/FitApp2/app/src/main/java/com/example/fitapp/presentation/ui/screens/onboarding/OnboardingPage.kt
@@ -1,0 +1,102 @@
+package com.example.fitapp.presentation.ui.screens.onboarding
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DirectionsRun
+import androidx.compose.material.icons.filled.EmojiEvents
+import androidx.compose.material.icons.filled.FitnessCenter
+import androidx.compose.material.icons.filled.TrendingUp
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun OnboardingPage(
+    icon: ImageVector,
+    title: String,
+    description: String,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = 32.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Box(
+            modifier = Modifier
+                .size(120.dp)
+                .clip(CircleShape)
+                .background(MaterialTheme.colorScheme.primaryContainer),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                modifier = Modifier.size(56.dp),
+                tint = MaterialTheme.colorScheme.primary
+            )
+        }
+
+        Text(
+            text = title,
+            style = MaterialTheme.typography.headlineMedium,
+            fontWeight = FontWeight.Bold,
+            textAlign = TextAlign.Center,
+            color = MaterialTheme.colorScheme.onBackground,
+            modifier = Modifier.padding(top = 32.dp, bottom = 16.dp)
+        )
+
+        Text(
+            text = description,
+            style = MaterialTheme.typography.bodyLarge,
+            textAlign = TextAlign.Center,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(horizontal = 16.dp)
+        )
+    }
+}
+
+object OnboardingData {
+    val pages = listOf(
+        OnboardingPageData(
+            icon = Icons.Default.FitnessCenter,
+            title = "Track Your Workouts",
+            description = "Log every rep, set, and exercise. Build custom routines or choose from pre-made plans designed by experts."
+        ),
+        OnboardingPageData(
+            icon = Icons.Default.TrendingUp,
+            title = "Set Your Goals",
+            description = "Define your fitness targets — daily steps, calories, workout frequency, or weight goals. We'll help you stay on track."
+        ),
+        OnboardingPageData(
+            icon = Icons.Default.EmojiEvents,
+            title = "See Real Progress",
+            description = "Visualize your journey with charts, personal records, and achievements. Every milestone gets the recognition it deserves."
+        )
+    )
+}
+
+data class OnboardingPageData(
+    val icon: ImageVector,
+    val title: String,
+    val description: String
+)

--- a/FitApp2/app/src/main/java/com/example/fitapp/presentation/ui/screens/onboarding/OnboardingScreen.kt
+++ b/FitApp2/app/src/main/java/com/example/fitapp/presentation/ui/screens/onboarding/OnboardingScreen.kt
@@ -1,0 +1,127 @@
+package com.example.fitapp.presentation.ui.screens.onboarding
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.animation.SizeTransform
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.example.fitapp.presentation.ui.theme.ButtonShape
+
+@OptIn(ExperimentalAnimationApi::class)
+@Composable
+fun OnboardingScreen(
+    onCompleted: () -> Unit
+) {
+    var currentPage by remember { mutableIntStateOf(0) }
+    val pages = OnboardingData.pages
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+            .padding(bottom = 32.dp)
+    ) {
+        AnimatedContent(
+            targetState = currentPage,
+            modifier = Modifier.weight(1f),
+            transitionSpec = {
+                val direction = if (targetState > initialState) 1 else -1
+                (fadeIn(tween(300)) + slideInHorizontally(tween(300)) { direction * it })
+                    .togetherWith(fadeOut(tween(300)) + slideOutHorizontally(tween(300)) { -direction * it })
+                    .using(SizeTransform(clip = false))
+            },
+            label = "onboarding"
+        ) {
+            OnboardingPage(
+                icon = pages[currentPage].icon,
+                title = pages[currentPage].title,
+                description = pages[currentPage].description
+            )
+        }
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 32.dp),
+            horizontalArrangement = Arrangement.Center
+        ) {
+            pages.forEachIndexed { index, _ ->
+                Box(
+                    modifier = Modifier
+                        .padding(4.dp)
+                        .size(if (index == currentPage) 10.dp else 8.dp)
+                        .clip(CircleShape)
+                        .background(
+                            if (index == currentPage) MaterialTheme.colorScheme.primary
+                            else MaterialTheme.colorScheme.outlineVariant
+                        )
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 32.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            TextButton(onClick = onCompleted) {
+                Text("Skip", color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+
+            Button(
+                onClick = {
+                    if (currentPage < pages.size - 1) {
+                        currentPage++
+                    } else {
+                        onCompleted()
+                    }
+                },
+                shape = ButtonShape,
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.primary
+                )
+            ) {
+                Text(
+                    text = if (currentPage < pages.size - 1) "Next" else "Get Started",
+                    fontWeight = FontWeight.SemiBold
+                )
+            }
+        }
+    }
+}

--- a/FitApp2/app/src/main/java/com/example/fitapp/presentation/ui/theme/FitnessColors.kt
+++ b/FitApp2/app/src/main/java/com/example/fitapp/presentation/ui/theme/FitnessColors.kt
@@ -1,0 +1,63 @@
+package com.example.fitapp.presentation.ui.theme
+
+import androidx.compose.ui.graphics.Color
+
+// Primary palette - Energetic orange
+val Orange500 = Color(0xFFFF6B35)
+val Orange400 = Color(0xFFFF8A5C)
+val Orange300 = Color(0xFFFFAA85)
+val Orange200 = Color(0xFFFFC9AD)
+val Orange100 = Color(0xFFFFE8D6)
+
+// Secondary palette - Deep teal
+val Teal700 = Color(0xFF004E64)
+val Teal600 = Color(0xFF006D8B)
+val Teal500 = Color(0xFF0092B8)
+val Teal400 = Color(0xFF33A8C6)
+val Teal300 = Color(0xFF66BED4)
+
+// Accent - Vibrant lime
+val Lime400 = Color(0xFFA5FF32)
+val Lime300 = Color(0xFFBFFF52)
+val Lime200 = Color(0xFFD6FF85)
+
+// Semantic colors
+val SuccessGreen = Color(0xFF4CAF50)
+val ErrorRed = Color(0xFFFF5252)
+val WarningAmber = Color(0xFFFFC107)
+val InfoBlue = Color(0xFF2196F3)
+
+// Neutral colors - Light theme
+val White = Color(0xFFFFFFFF)
+val Gray50 = Color(0xFFF8F9FA)
+val Gray100 = Color(0xFFF1F3F5)
+val Gray200 = Color(0xFFE9ECEF)
+val Gray300 = Color(0xFFDEE2E6)
+val Gray400 = Color(0xFFCED4DA)
+val Gray500 = Color(0xFFADB5BD)
+val Gray600 = Color(0xFF868E96)
+val Gray700 = Color(0xFF495057)
+val Gray800 = Color(0xFF343A40)
+val Gray900 = Color(0xFF212529)
+
+// Neutral colors - Dark theme
+val DarkSurface = Color(0xFF1E1E2E)
+val DarkBackground = Color(0xFF121218)
+val DarkSurfaceVariant = Color(0xFF2A2A3C)
+
+// OLED Dark theme
+val OledBlack = Color(0xFF000000)
+val OledSurface = Color(0xFF0A0A0F)
+val OledSurfaceVariant = Color(0xFF1A1A24)
+
+// Stats colors for charts
+val ChartBlue = Color(0xFF3B82F6)
+val ChartPurple = Color(0xFF8B5CF6)
+val ChartPink = Color(0xFFEC4899)
+val ChartCyan = Color(0xFF06B6D4)
+
+// Heart / health colors
+val HeartRed = Color(0xFFE53935)
+val CalorieOrange = Color(0xFFFF9800)
+val HydrateBlue = Color(0xFF29B6F6)
+val StepsGreen = Color(0xFF66BB6A)

--- a/FitApp2/app/src/main/java/com/example/fitapp/presentation/ui/theme/FitnessShapes.kt
+++ b/FitApp2/app/src/main/java/com/example/fitapp/presentation/ui/theme/FitnessShapes.kt
@@ -1,0 +1,19 @@
+package com.example.fitapp.presentation.ui.theme
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Shapes
+import androidx.compose.ui.unit.dp
+
+val FitnessShapes = Shapes(
+    extraSmall = RoundedCornerShape(4.dp),
+    small = RoundedCornerShape(8.dp),
+    medium = RoundedCornerShape(12.dp),
+    large = RoundedCornerShape(16.dp),
+    extraLarge = RoundedCornerShape(24.dp)
+)
+
+val CardShape = RoundedCornerShape(16.dp)
+val ButtonShape = RoundedCornerShape(12.dp)
+val ChipShape = RoundedCornerShape(20.dp)
+val ProgressBarShape = RoundedCornerShape(8.dp)
+val CircleShape = RoundedCornerShape(50)

--- a/FitApp2/app/src/main/java/com/example/fitapp/presentation/ui/theme/FitnessTypography.kt
+++ b/FitApp2/app/src/main/java/com/example/fitapp/presentation/ui/theme/FitnessTypography.kt
@@ -1,0 +1,141 @@
+package com.example.fitapp.presentation.ui.theme
+
+import androidx.compose.material3.Typography
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+
+val FitnessTypography = Typography(
+    displayLarge = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Bold,
+        fontSize = 57.sp,
+        lineHeight = 64.sp,
+        letterSpacing = (-0.25).sp
+    ),
+    displayMedium = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Bold,
+        fontSize = 45.sp,
+        lineHeight = 52.sp,
+        letterSpacing = 0.sp
+    ),
+    displaySmall = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Bold,
+        fontSize = 36.sp,
+        lineHeight = 44.sp,
+        letterSpacing = 0.sp
+    ),
+    headlineLarge = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Bold,
+        fontSize = 32.sp,
+        lineHeight = 40.sp,
+        letterSpacing = 0.sp
+    ),
+    headlineMedium = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.SemiBold,
+        fontSize = 28.sp,
+        lineHeight = 36.sp,
+        letterSpacing = 0.sp
+    ),
+    headlineSmall = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.SemiBold,
+        fontSize = 24.sp,
+        lineHeight = 32.sp,
+        letterSpacing = 0.sp
+    ),
+    titleLarge = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.SemiBold,
+        fontSize = 22.sp,
+        lineHeight = 28.sp,
+        letterSpacing = 0.sp
+    ),
+    titleMedium = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Medium,
+        fontSize = 16.sp,
+        lineHeight = 24.sp,
+        letterSpacing = 0.15.sp
+    ),
+    titleSmall = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Medium,
+        fontSize = 14.sp,
+        lineHeight = 20.sp,
+        letterSpacing = 0.1.sp
+    ),
+    bodyLarge = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Normal,
+        fontSize = 16.sp,
+        lineHeight = 24.sp,
+        letterSpacing = 0.5.sp
+    ),
+    bodyMedium = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Normal,
+        fontSize = 14.sp,
+        lineHeight = 20.sp,
+        letterSpacing = 0.25.sp
+    ),
+    bodySmall = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Normal,
+        fontSize = 12.sp,
+        lineHeight = 16.sp,
+        letterSpacing = 0.4.sp
+    ),
+    labelLarge = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Medium,
+        fontSize = 14.sp,
+        lineHeight = 20.sp,
+        letterSpacing = 0.1.sp
+    ),
+    labelMedium = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Medium,
+        fontSize = 12.sp,
+        lineHeight = 16.sp,
+        letterSpacing = 0.5.sp
+    ),
+    labelSmall = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Medium,
+        fontSize = 11.sp,
+        lineHeight = 16.sp,
+        letterSpacing = 0.5.sp
+    )
+)
+
+// Fitness-specific text styles
+val HeroNumberStyle = TextStyle(
+    fontFamily = FontFamily.Default,
+    fontWeight = FontWeight.Bold,
+    fontSize = 48.sp,
+    lineHeight = 56.sp,
+    letterSpacing = (-1).sp
+)
+
+val StatLabelStyle = TextStyle(
+    fontFamily = FontFamily.Default,
+    fontWeight = FontWeight.Medium,
+    fontSize = 12.sp,
+    lineHeight = 16.sp,
+    letterSpacing = 0.5.sp
+)
+
+val SectionTitleStyle = TextStyle(
+    fontFamily = FontFamily.Default,
+    fontWeight = FontWeight.Bold,
+    fontSize = 18.sp,
+    lineHeight = 24.sp,
+    letterSpacing = 0.sp
+)

--- a/FitApp2/app/src/main/java/com/example/fitapp/presentation/ui/theme/Theme.kt
+++ b/FitApp2/app/src/main/java/com/example/fitapp/presentation/ui/theme/Theme.kt
@@ -1,58 +1,108 @@
 package com.example.fitapp.presentation.ui.theme
 
-import android.app.Activity
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
-import androidx.compose.material3.dynamicDarkColorScheme
-import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.platform.LocalContext
-
-private val DarkColorScheme = darkColorScheme(
-    primary = Purple80,
-    secondary = PurpleGrey80,
-    tertiary = Pink80
-)
 
 private val LightColorScheme = lightColorScheme(
-    primary = Purple40,
-    secondary = PurpleGrey40,
-    tertiary = Pink40
-
-    /* Other default colors to override
-    background = Color(0xFFFFFBFE),
-    surface = Color(0xFFFFFBFE),
-    onPrimary = Color.White,
-    onSecondary = Color.White,
-    onTertiary = Color.White,
-    onBackground = Color(0xFF1C1B1F),
-    onSurface = Color(0xFF1C1B1F),
-    */
+    primary = Orange500,
+    onPrimary = White,
+    primaryContainer = Orange100,
+    onPrimaryContainer = Color(0xFF3D1500),
+    secondary = Teal700,
+    onSecondary = White,
+    secondaryContainer = Teal300.copy(alpha = 0.3f),
+    onSecondaryContainer = Color(0xFF001F29),
+    tertiary = Lime400,
+    onTertiary = Color(0xFF1A3300),
+    tertiaryContainer = Lime200.copy(alpha = 0.3f),
+    onTertiaryContainer = Color(0xFF0D1A00),
+    error = ErrorRed,
+    onError = White,
+    errorContainer = ErrorRed.copy(alpha = 0.1f),
+    background = Gray50,
+    onBackground = Gray900,
+    surface = White,
+    onSurface = Gray900,
+    surfaceVariant = Gray100,
+    onSurfaceVariant = Gray600,
+    outline = Gray300,
+    outlineVariant = Gray200
 )
+
+private val DarkColorScheme = darkColorScheme(
+    primary = Orange400,
+    onPrimary = Color(0xFF3D1500),
+    primaryContainer = Orange500.copy(alpha = 0.2f),
+    onPrimaryContainer = Orange200,
+    secondary = Teal400,
+    onSecondary = Color(0xFF001F29),
+    secondaryContainer = Teal500.copy(alpha = 0.2f),
+    onSecondaryContainer = Teal300,
+    tertiary = Lime300,
+    onTertiary = Color(0xFF0D1A00),
+    tertiaryContainer = Lime400.copy(alpha = 0.2f),
+    onTertiaryContainer = Lime200,
+    error = ErrorRed,
+    onError = White,
+    errorContainer = ErrorRed.copy(alpha = 0.2f),
+    background = DarkBackground,
+    onBackground = Gray200,
+    surface = DarkSurface,
+    onSurface = Gray200,
+    surfaceVariant = DarkSurfaceVariant,
+    onSurfaceVariant = Gray500,
+    outline = Gray600,
+    outlineVariant = Gray700
+)
+
+private val OledDarkColorScheme = darkColorScheme(
+    primary = Orange400,
+    onPrimary = Color(0xFF3D1500),
+    primaryContainer = Orange500.copy(alpha = 0.15f),
+    onPrimaryContainer = Orange200,
+    secondary = Teal400,
+    onSecondary = Color(0xFF001F29),
+    secondaryContainer = Teal500.copy(alpha = 0.15f),
+    onSecondaryContainer = Teal300,
+    tertiary = Lime300,
+    onTertiary = Color(0xFF0D1A00),
+    tertiaryContainer = Lime400.copy(alpha = 0.15f),
+    onTertiaryContainer = Lime200,
+    error = ErrorRed,
+    onError = White,
+    errorContainer = ErrorRed.copy(alpha = 0.15f),
+    background = OledBlack,
+    onBackground = Gray300,
+    surface = OledSurface,
+    onSurface = Gray300,
+    surfaceVariant = OledSurfaceVariant,
+    onSurfaceVariant = Gray500,
+    outline = Gray700,
+    outlineVariant = Gray800
+)
+
+import androidx.compose.ui.graphics.Color
 
 @Composable
 fun FitAppTheme(
-    darkTheme: Boolean = isSystemInDarkTheme(),
-    // Dynamic color is available on Android 12+
-    dynamicColor: Boolean = true,
+    themeMode: ThemeMode = ThemeMode.DARK,
+    dynamicColor: Boolean = false,
     content: @Composable () -> Unit
 ) {
-    val colorScheme = when {
-        dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
-            val context = LocalContext.current
-            if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
-        }
-
-        darkTheme -> DarkColorScheme
-        else -> LightColorScheme
+    val colorScheme = when (themeMode) {
+        ThemeMode.LIGHT -> LightColorScheme
+        ThemeMode.DARK -> DarkColorScheme
+        ThemeMode.OLED_DARK -> OledDarkColorScheme
     }
 
     MaterialTheme(
         colorScheme = colorScheme,
-        typography = Typography,
+        typography = FitnessTypography,
+        shapes = FitnessShapes,
         content = content
     )
 }

--- a/FitApp2/app/src/main/java/com/example/fitapp/presentation/ui/theme/ThemeMode.kt
+++ b/FitApp2/app/src/main/java/com/example/fitapp/presentation/ui/theme/ThemeMode.kt
@@ -1,0 +1,7 @@
+package com.example.fitapp.presentation.ui.theme
+
+enum class ThemeMode {
+    LIGHT,
+    DARK,
+    OLED_DARK
+}

--- a/FitApp2/app/src/main/java/com/example/fitapp/presentation/ui/theme/screen/LoginScreen.kt
+++ b/FitApp2/app/src/main/java/com/example/fitapp/presentation/ui/theme/screen/LoginScreen.kt
@@ -1,7 +1,6 @@
 package com.example.fitapp.presentation.ui.theme.screen
 
 import android.content.Intent
-import android.util.Log
 import android.widget.Toast
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.CircularProgressIndicator
@@ -12,7 +11,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
-import androidx.core.content.ContextCompat.startActivity
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.example.fitapp.MainActivity
 import com.example.fitapp.presentation.ui.component.AuthForm
@@ -35,30 +33,24 @@ fun AuthScreen(
                     Toast.makeText(context, effect.message, Toast.LENGTH_SHORT).show()
                 }
                 AuthEffect.NavigateToDashboard -> {
-                    Toast.makeText(context, "", Toast.LENGTH_SHORT).show()
-
+                    val sendIntent = Intent(context, MainActivity::class.java)
+                    context.startActivity(sendIntent)
                 }
             }
         }
     }
 
-    // UI based on state
-    Log.d("LoginScreen", "state -> ${state.value}")
     when (state.value) {
-        is AuthState.Idle -> AuthForm(onEvent = {
-            Log.d("LoginScreen", "state -> ${it.toString()}")
-
-            viewModel.setEvent(it) })
+        is AuthState.Idle -> AuthForm(onEvent = { viewModel.setEvent(it) })
         is AuthState.Loading -> CircularProgressIndicator()
         is AuthState.Error -> {
-            AuthForm(onEvent = {
-                Log.d("LoginScreen", "state -> ${it.toString()}")
-                viewModel.setEvent(it) })
-            Text(text = "Error: ${(state.value as AuthState.Error).error}", modifier = Modifier.padding(16.dp))
-
+            AuthForm(onEvent = { viewModel.setEvent(it) })
+            Text(
+                text = "Error: ${(state.value as AuthState.Error).error}",
+                modifier = Modifier.padding(16.dp)
+            )
         }
         is AuthState.Success -> {
-            Log.d("LoginScreen", "state -> ${state.value}")
             val sendIntent = Intent(context, MainActivity::class.java)
             context.startActivity(sendIntent)
         }

--- a/FitApp2/app/src/main/java/com/example/fitapp/presentation/ui/viewModel/LoginViewModel.kt
+++ b/FitApp2/app/src/main/java/com/example/fitapp/presentation/ui/viewModel/LoginViewModel.kt
@@ -21,11 +21,41 @@ class LoginViewModel @Inject constructor(
 
     override fun createInitialState(): AuthState = AuthState.Idle
 
-
     override fun handleEvent(event: AuthEvent) {
         when (event) {
-            is AuthEvent.Login -> login(event.email, event.password)
-            is AuthEvent.Register -> register(event.email, event.password)
+            is AuthEvent.Login -> {
+                if (validateInput(event.email, event.password)) {
+                    login(event.email.trim(), event.password)
+                }
+            }
+            is AuthEvent.Register -> {
+                if (validateInput(event.email, event.password)) {
+                    register(event.email.trim(), event.password)
+                }
+            }
+        }
+    }
+
+    private fun validateInput(email: String, password: String): Boolean {
+        val emailRegex = Regex("^[A-Za-z0-9._%+\\-]+@[A-Za-z0-9.\\-]+\\.[A-Za-z]{2,}$")
+        return when {
+            email.isBlank() -> {
+                setEffect { AuthEffect.ShowToast("Email cannot be empty") }
+                false
+            }
+            !emailRegex.matches(email.trim()) -> {
+                setEffect { AuthEffect.ShowToast("Invalid email format") }
+                false
+            }
+            password.length < 8 -> {
+                setEffect { AuthEffect.ShowToast("Password must be at least 8 characters") }
+                false
+            }
+            password.isBlank() -> {
+                setEffect { AuthEffect.ShowToast("Password cannot be empty") }
+                false
+            }
+            else -> true
         }
     }
 
@@ -72,5 +102,3 @@ class LoginViewModel @Inject constructor(
 
 
 }
-
-

--- a/FitApp2/app/src/main/java/com/example/fitapp/presentation/ui/viewModel/MainActivityViewModel.kt
+++ b/FitApp2/app/src/main/java/com/example/fitapp/presentation/ui/viewModel/MainActivityViewModel.kt
@@ -1,10 +1,10 @@
 package com.example.fitapp.presentation.ui.viewModel
 
-
 import com.example.fitapp.presentation.ui.mvi.effect.MainActivityEffect
 import com.example.fitapp.presentation.ui.mvi.event.MainActivityEvent
 import com.example.fitapp.presentation.ui.mvi.state.MainActivityState
 import androidx.lifecycle.viewModelScope
+import com.example.fitapp.data.local.datastore.DataStoreManager
 import com.example.fitapp.data.local.sensor.StepCounter
 import com.example.fitapp.domain.usecases.GetStepsUseCase
 import com.example.fitapp.domain.usecases.InsertStepsUseCase
@@ -12,6 +12,9 @@ import com.example.fitapp.presentation.ui.mvi.projectStructure.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -20,11 +23,20 @@ class MainActivityViewModel @Inject constructor(
     private val stepsUseCase: InsertStepsUseCase,
     private val getStepsUseCase: GetStepsUseCase,
     private val stepCounter: StepCounter,
+    private val dataStoreManager: DataStoreManager
+) : BaseViewModel<MainActivityEvent, MainActivityState, MainActivityEffect>() {
 
-)
-    :BaseViewModel<MainActivityEvent, MainActivityState, MainActivityEffect>() {
+    val onboardingCompleted: StateFlow<Boolean> = dataStoreManager
+        .isOnboardingCompleted()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
+
     override fun createInitialState(): MainActivityState = MainActivityState.Idle
 
+    fun completeOnboarding() {
+        viewModelScope.launch {
+            dataStoreManager.setOnboardingCompleted()
+        }
+    }
 
     override fun handleEvent(event: MainActivityEvent) {
         when (event) {
@@ -50,16 +62,14 @@ class MainActivityViewModel @Inject constructor(
                             setEffect { MainActivityEffect.ShowToast("Error getting steps: ${error.message}") }
                         }
                     )
+                }
         }
     }
-    }
-
 
     private fun insertSteps() {
         viewModelScope.launch {
-        val steps =  stepCounter.steps()
+            val steps = stepCounter.steps()
             stepsUseCase(steps)
         }
     }
-
 }

--- a/FitApp2/app/src/main/java/com/example/fitapp/presentation/ui/viewModel/MainActivityViewModel.kt
+++ b/FitApp2/app/src/main/java/com/example/fitapp/presentation/ui/viewModel/MainActivityViewModel.kt
@@ -1,9 +1,9 @@
 package com.example.fitapp.presentation.ui.viewModel
 
 
-import MainActivityEffect
-import MainActivityEvent
-import MainActivityState
+import com.example.fitapp.presentation.ui.mvi.effect.MainActivityEffect
+import com.example.fitapp.presentation.ui.mvi.event.MainActivityEvent
+import com.example.fitapp.presentation.ui.mvi.state.MainActivityState
 import androidx.lifecycle.viewModelScope
 import com.example.fitapp.data.local.sensor.StepCounter
 import com.example.fitapp.domain.usecases.GetStepsUseCase

--- a/FitApp2/app/src/main/res/xml/network_security_config.xml
+++ b/FitApp2/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config cleartextTrafficPermitted="false">
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
+    <domain-config cleartextTrafficPermitted="false">
+        <domain includeSubdomains="true">firebaseio.com</domain>
+        <domain includeSubdomains="true">googleapis.com</domain>
+        <domain includeSubdomains="true">google.com</domain>
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
## Summary
Adds onboarding flow, bottom navigation with 5 tabs, and extended DataStore preferences for future features.

### New Features
- **3-page onboarding carousel** with animated transitions (swipe-style page changes)
- **Skip/Next/Get Started** flow that persists completion to DataStore
- **Bottom navigation bar** with 5 tabs: Home, Workouts, Track, Progress, Profile
- **Active/inactive icon states** for each nav item with proper tinting
- **AppNavigation composable** wiring tabs to screens (placeholder screens for future PRs)
- **Extended DataStore** with preferences for: onboarding state, theme mode, daily goals, unit system

### Files
- `OnboardingScreen.kt` - Carousel with animated page transitions + indicator dots
- `OnboardingPage.kt` - Individual page composable with icon, title, description + page data
- `FitBottomNav.kt` - Material 3 NavigationBar with 5 fitness-themed tabs
- `AppNavigation.kt` - Main scaffold with bottom bar + tab content routing
- `DataStoreManager.kt` - Extended with 8 new preference keys (onboarding, theme, goals, units)
- `MainActivity.kt` - Rewired to show onboarding first, then app navigation
- `MainActivityViewModel.kt` - Added `onboardingCompleted` StateFlow + completion handler

### Navigation Flow
```
Login → Onboarding (first time only) → Main App (with bottom nav)
```